### PR TITLE
[WIP] Add Linux support

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 colorama==0.3.9
 oletools==0.60
-pyinstaller==4.10
+pyinstaller==6.3.0

--- a/scripts/linux/build
+++ b/scripts/linux/build
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+set -e
+
+export PYTHON_ARCH=$(python -c "import sys;print('x64' if sys.maxsize > 2**32 else 'x86')")
+
+python ./scripts/linux/update-version-info.py
+pyinstaller --onefile ./src/diff.py --name=git-xl-diff-$PYTHON_ARCH --version-file ./scripts/windows/git-xl-version-info.py --icon ./scripts/windows/git-xl-logo.ico
+pyinstaller --onefile ./src/cli.py --name=git-xl-$PYTHON_ARCH --version-file ./scripts/windows/git-xl-version-info.py --icon ./scripts/windows/git-xl-logo.ico

--- a/scripts/linux/update-version-info.py
+++ b/scripts/linux/update-version-info.py
@@ -1,0 +1,66 @@
+import os
+import json
+import re
+
+base_directory = os.path.join('scripts', 'linux')
+
+# read build number, repo tag name and git commit hash from env vars 
+build = os.getenv('APPVEYOR_BUILD_NUMBER', '0') 
+version = os.getenv('APPVEYOR_REPO_TAG_NAME', '0.0.0')
+commit = os.environ['APPVEYOR_REPO_COMMIT'][:7] if os.getenv('APPVEYOR_REPO_COMMIT') else 'dev'
+
+print('-----------')
+print('Version tag: %s' % version)
+print('Build number: %s' % build)
+print('Commit hash: %s' % commit)
+
+major, minor, patch = version.split('.')
+print(f'Generate file version: {major}.{minor}.{patch}.{build}')
+print('-----------')
+
+
+
+s = f"""VSVersionInfo(
+  ffi=FixedFileInfo(
+    filevers=({major}, {minor}, {patch}, {build}),
+    prodvers=({major}, {minor}, {patch}, {build}),
+    mask=0x3f,
+    flags=0x0,
+    OS=0x40004,
+    fileType=0x1,
+    subtype=0x0,
+    date=(0, 0)
+    ),
+  kids=[
+    StringFileInfo(
+      [
+      StringTable(
+        u'040904B0',
+        [StringStruct(u'CompanyName', u'Zoomer Analytics LLC'),
+        StringStruct(u'FileDescription', u'Git XL'),
+        StringStruct(u'FileVersion', u'{major}.{minor}.{patch}'),
+        StringStruct(u'InternalName', u'git-xl'),
+        StringStruct(u'LegalCopyright', u'Zoomer Analytics LLC'),
+        StringStruct(u'OriginalFilename', u'git-xl'),
+        StringStruct(u'ProductName', u'Git XL'),
+        StringStruct(u'ProductVersion', u'{major}.{minor}.{patch}')])
+      ]), 
+    VarFileInfo([VarStruct(u'Translation', [1033, 1200])])
+  ]
+)"""
+
+# update 'git-xl-version-info.py
+path = os.path.join(base_directory, 'git-xl-version-info.py')
+with open(path, 'w') as f:
+    f.write(s)
+
+# update git-xl.py (VERSION and COMMIT)
+path = 'src/cli.py'
+with open(path, 'r') as f:
+    s = f.read()
+
+s = re.sub("VERSION\s*=\s*('|\")\d\.\d.\d('|\")", f"VERSION = '{major}.{minor}.{patch}'", s, re.MULTILINE)
+s = re.sub("GIT_COMMIT\s*=\s*('|\")[a-zA-Z0-9]*('|\")", f"GIT_COMMIT = '{commit}'", s, re.MULTILINE)
+
+with open(path, 'w') as f:
+    f.write(s)


### PR DESCRIPTION
`scripts/linux/build` is a modified version of `scripts/windows/build.bat`.
    
It just takes the modified `./scripts/linux/update-version-info.py` + the unmodified `./scripts/windows/git-xl-version-info.py` files and uses them to build the binary via pyinstaller.

I also updated pytinstaller to fix the following problem:

```
      ❯ pip install -r requirements.txt
      Collecting colorama==0.3.9
        Using cached colorama-0.3.9-py2.py3-none-any.whl (20 kB)
      Collecting oletools==0.60
        Using cached oletools-0.60-py2.py3-none-any.whl (968 kB)
      ERROR: Ignored the following versions that require a different python version: 4.10 Requires-Python <3.11,>=3.6; 4.6 Requires-Python <3.11,>=3.6; 4.7 Requires-Python <3.11,>=3.6; 4.8 Requires-Python <3.11,>=3.6; 4.9 Requires-Python <3.11,>=3.6; 5.0 Requires-Python <3.11,>=3.7; 5.0.1 Requires-Python <3.11,>=3.7; 5.1 Requires-Python <3.11,>=3.7; 5.2 Requires-Python <3.11,>=3.7; 5.3 Requires-Python <3.11,>=3.7; 5.4 Requires-Python <3.11,>=3.7; 5.4.1 Requires-Python <3.11,>=3.7
      ERROR: Could not find a version that satisfies the requirement pyinstaller==4.10 (from versions: 2.0, 2.1, 3.0, 3.1, 3.1.1, 3.2, 3.2.1, 3.3, 3.3.1, 3.4, 3.5, 3.6, 4.0, 4.1, 4.2, 4.3, 4.4, 4.5, 4.5.1, 5.5, 5.6, 5.6.1, 5.6.2, 5.7.0, 5.8.0, 5.9.0, 5.10.0, 5.10.1, 5.11.0, 5.12.0, 5.13.0, 5.13.1, 5.13.2, 6.0.0, 6.1.0, 6.2.0, 6.3.0)
      ERROR: No matching distribution found for pyinstaller==4.10
```

It builds:

```
❯ scripts/linux/build                 
-----------                                                         
Version tag: 0.0.0                                                                                                                      
Build number: 0                                                                                                                         
Commit hash: dev                                                                                                                        
Generate file version: 0.0.0.0                                      
-----------                                                         
81 INFO: PyInstaller: 6.3.0                                                                                                             
81 INFO: Python: 3.11.2                                                                                                                 
82 INFO: Platform: Linux-6.1.0-17-amd64-x86_64-with-glibc2.36                                                                           
82 INFO: wrote /home/jkirk/projects/python-dev/git-xl/git-xl-diff-x64.spec                                                              
83 INFO: Extending PYTHONPATH with paths                            
['/home/jkirk/projects/python-dev/git-xl/src'] 
[...]
2598 INFO: checking PKG
2598 INFO: Building because toc changed
2598 INFO: Building PKG (CArchive) git-xl-x64.pkg
4750 INFO: Building PKG (CArchive) git-xl-x64.pkg completed successfully.
4750 INFO: Bootloader /home/jkirk/projects/python-dev/git-xl/venv3/lib/python3.11/site-packages/PyInstaller/bootloader/Linux-64bit-intel/run
4750 INFO: checking EXE
4751 INFO: Building because toc changed
4751 INFO: Building EXE from EXE-00.toc
4751 INFO: Copying bootloader EXE to /home/jkirk/projects/python-dev/git-xl/dist/git-xl-x64
4752 INFO: Appending PKG archive to custom ELF section in EXE
4763 INFO: Building EXE from EXE-00.toc completed successfully.
scripts/linux/build  13,22s user 0,57s system 98% cpu 13,928 total
```

And `./git-xl-x64` runs:

```
 ❯ ./git-xl-x64 --help
git-xl/0.0.0 (windows; Python 3.11.2); git dev
git xl <command> [<args>]

Git xl is a system for managing Excel workbook files in
association with a Git repository. Git xl:
* installs a special git-diff for Excel workbook files 
* makes Git ignore temporary Excel files via .gitignore

Commands
--------

* git xl env:
    Display the Git xl environment.
* git xl version:
    Report the version number.
* git xl install:
    Install Git xl.
* git xl uninstall:
    Uninstall Git xl.
```

But there are still things to do, to make it work and close #39. Until then, I mark this as `[WIP]`.